### PR TITLE
Remove showkase module's dependency on ui-tooling

### DIFF
--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -72,7 +72,6 @@ dependencies {
     implementation deps.compose.composeNavigation
     implementation deps.compose.core
     implementation deps.compose.foundation
-    implementation deps.compose.tooling
     implementation deps.compose.layout
     implementation deps.compose.material
     androidTestImplementation deps.compose.uiTest


### PR DESCRIPTION
`androidx.compose.ui:ui-tooling` doesn't seem to be used anyway in the main module so remove it to avoid pulling in unneeded dependencies for consumers.